### PR TITLE
contrib: live status updates on any computer

### DIFF
--- a/contrib/livestat_standalone/README.md
+++ b/contrib/livestat_standalone/README.md
@@ -1,3 +1,36 @@
 # HTTP updates endpoint as a single executable
 
 Written in Golang, striving for a single executable deploy. This is written as a testimonial to how terribly unfit Cloud is for inherently tiny use cases like these.
+
+## Configuration
+
+Set environment variables:
+
+- `LISTEN` (optional) \
+  `host:port` pair to listen at. Specified in golang `net/http` syntax. Default value `:38083`.
+- `MASTER_TOKEN` (optional) \
+  Token used to authenticate and authorize service creation, deletion, and updates.
+- `DATA_FILE` (optional) \
+  When specified, attempt to load state on startup, and save on every change to services.
+  When unspecified. the entire state resides in memory only.
+
+## Deploy
+
+Run `go build` to generate the executable. Configure environment variables as needed. Run the executable.
+You probably also wants to setup a reverse proxy like Nginx or Caddy to handle HTTPS termination.
+
+Example:
+```sh
+export LISTEN=':8080'
+export MASTER_TOKEN=hunter2
+export DATA_FILE=data.json
+./livestat_standalone
+```
+
+## Design Considerations
+
+To keep it simple, every service resides in memory at all times. This should scale well up to tens of thousands of services, given enough memory.
+The entire state file is overwritten on every change. This scale work well up to hundreds of services, but beyond that there may occur thrashing of disk.
+
+Both of these scalability issues can be easily mitigated by using SQLite. The limit then becomes service update frequency (roughly tens of thousands per second), and disk size (however big your attached storage is).
+SQLite is not used here because it's an extra dependency, and we're small enough there is just no point.

--- a/contrib/livestat_standalone/README.md
+++ b/contrib/livestat_standalone/README.md
@@ -1,0 +1,3 @@
+# HTTP updates endpoint as a single executable
+
+Written in Golang, striving for a single executable deploy. This is written as a testimonial to how terribly unfit Cloud is for inherently tiny use cases like these.

--- a/contrib/livestat_standalone/go.mod
+++ b/contrib/livestat_standalone/go.mod
@@ -1,0 +1,3 @@
+module github.com/SJSUCSClub/acm-bot/contrib/livestat_standalone
+
+go 1.23.5

--- a/contrib/livestat_standalone/main.go
+++ b/contrib/livestat_standalone/main.go
@@ -15,11 +15,9 @@ import (
 var masterToken string
 
 type Service struct {
-	id string
-
-	status string
-
-	lastUpdated time.Time
+	Id          string    `json:"-"`
+	Status      string    `json:"status"`
+	LastUpdated time.Time `json:"lastUpdated"`
 }
 
 type LiveStats struct {
@@ -78,7 +76,7 @@ func (ls *LiveStats) handlerMain(w http.ResponseWriter, req *http.Request) {
 				continue
 			}
 			fmt.Fprintf(w, "<tr><td>%s</td><td>%s</td><td>%s</td></tr>",
-				service.id, service.status, service.lastUpdated.Local().String())
+				service.Id, service.Status, service.LastUpdated.Local().String())
 		}
 		fmt.Fprint(w, "</table>")
 		fmt.Fprint(w, "</body></html>")
@@ -90,10 +88,10 @@ func (ls *LiveStats) handlerMain(w http.ResponseWriter, req *http.Request) {
 			if !exists {
 				continue
 			}
-			fmt.Fprintf(w, `%s
-since: %s
-is: %s\n`,
-				service.id, service.lastUpdated.Local().String(), service.status)
+			fmt.Fprintf(w, "%s\nsince: %s\nis: %s\n\n",
+				service.Id,
+				service.LastUpdated.Local().Format("2006-01-02 15:04:05 UTC-07"),
+				service.Status)
 		}
 	default:
 		http.Error(w, "Invalid format", http.StatusBadRequest)
@@ -119,9 +117,9 @@ func (ls *LiveStats) handlerNewService(w http.ResponseWriter, req *http.Request)
 	}
 
 	ls.services[id] = &Service{
-		id:          id,
-		status:      "",
-		lastUpdated: time.Now(),
+		Id:          id,
+		Status:      "",
+		LastUpdated: time.Now(),
 	}
 }
 
@@ -147,8 +145,8 @@ func (ls *LiveStats) handlerUpdateStatus(w http.ResponseWriter, req *http.Reques
 		http.Error(w, "", http.StatusInternalServerError)
 	}
 
-	service.status = string(body)
-	service.lastUpdated = time.Now()
+	service.Status = string(body)
+	service.LastUpdated = time.Now()
 }
 
 func (ls *LiveStats) handlerDeleteService(w http.ResponseWriter, req *http.Request) {

--- a/contrib/livestat_standalone/main.go
+++ b/contrib/livestat_standalone/main.go
@@ -232,5 +232,5 @@ func main() {
 	http.HandleFunc("POST /service", state.handlerNewService)
 	http.HandleFunc("POST /service/status", state.handlerUpdateStatus)
 	http.HandleFunc("DELETE /service", state.handlerDeleteService)
-	http.ListenAndServe(":38083", nil)
+	http.ListenAndServe(stringDefault(os.Getenv("LISTEN"), ":38083"), nil)
 }

--- a/contrib/livestat_standalone/main.go
+++ b/contrib/livestat_standalone/main.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Initialize in main() and NEVER changed again
+var masterToken string
+
+type Service struct {
+	id string
+
+	status string
+
+	lastUpdated time.Time
+}
+
+type LiveStats struct {
+	services map[string]*Service
+
+	usage sync.RWMutex
+}
+
+func (ls *LiveStats) save() {
+
+}
+
+func stringDefault(a string, b string) string {
+	if a == "" {
+		return b
+	}
+	return a
+}
+
+const HTML_STYLES = `
+<style>
+table { border-collapse: collapse; }
+th, td { border: 1px solid black; padding: 0.5em; }
+</style>`
+
+func (ls *LiveStats) handlerMain(w http.ResponseWriter, req *http.Request) {
+	servicesId := strings.Split(req.FormValue("services"), ",")
+	format := stringDefault(req.FormValue("format"), "json")
+
+	ls.usage.RLock()
+	defer ls.usage.RUnlock()
+
+	w.Header().Add("Cache-Control", "max-age=300")
+	switch format {
+	case "json":
+		w.Header().Add("Content-Type", "application/json")
+		// ... first call to w.Write() below:
+		// NOTE: potential memory pressure problem, if clients asks for too many services too quickly, for constructing this map
+		res := make(map[string]*Service, len(servicesId))
+		for _, id := range servicesId {
+			service, exists := ls.services[id]
+			if !exists {
+				continue
+			}
+			res[id] = service
+		}
+		json.NewEncoder(w).Encode(res)
+	case "html":
+		w.Header().Add("Content-Type", "text/html")
+		// ... first call to w.Write() below:
+		fmt.Fprint(w, "<html><head>", HTML_STYLES, "</head><body>")
+		fmt.Fprint(w, "<table>", "<tr><th>Service</th><th>Status</th><th>Last Updated</th></tr>")
+		for _, id := range servicesId {
+			service, exists := ls.services[id]
+			if !exists {
+				continue
+			}
+			fmt.Fprintf(w, "<tr><td>%s</td><td>%s</td><td>%s</td></tr>",
+				service.id, service.status, service.lastUpdated.Local().String())
+		}
+		fmt.Fprint(w, "</table>")
+		fmt.Fprint(w, "</body></html>")
+	case "plaintext":
+		w.Header().Add("Content-Type", "text/plain")
+		// ... first call to w.Write() below:
+		for _, id := range servicesId {
+			service, exists := ls.services[id]
+			if !exists {
+				continue
+			}
+			fmt.Fprintf(w, `%s
+since: %s
+is: %s\n`,
+				service.id, service.lastUpdated.Local().String(), service.status)
+		}
+	default:
+		http.Error(w, "Invalid format", http.StatusBadRequest)
+		return
+	}
+}
+
+func (ls *LiveStats) handlerNewService(w http.ResponseWriter, req *http.Request) {
+	token := req.FormValue("token")
+	if token != masterToken {
+		http.Error(w, "Invalid token", http.StatusUnauthorized)
+		return
+	}
+
+	ls.usage.Lock()
+	defer ls.usage.Unlock()
+
+	id := req.FormValue("id")
+	_, exists := ls.services[id]
+	if exists {
+		http.Error(w, "Service already exists", http.StatusConflict)
+		return
+	}
+
+	ls.services[id] = &Service{
+		id:          id,
+		status:      "",
+		lastUpdated: time.Now(),
+	}
+}
+
+func (ls *LiveStats) handlerUpdateStatus(w http.ResponseWriter, req *http.Request) {
+	token := req.FormValue("token")
+	if token != masterToken {
+		http.Error(w, "Invalid token", http.StatusUnauthorized)
+		return
+	}
+
+	ls.usage.Lock()
+	defer ls.usage.Unlock()
+
+	service, exists := ls.services[req.FormValue("id")]
+	if !exists {
+		http.Error(w, "Service does not exist", http.StatusBadRequest)
+		return
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		// This shouldn't happen
+		http.Error(w, "", http.StatusInternalServerError)
+	}
+
+	service.status = string(body)
+	service.lastUpdated = time.Now()
+}
+
+func (ls *LiveStats) handlerDeleteService(w http.ResponseWriter, req *http.Request) {
+	token := req.FormValue("token")
+	if token != masterToken {
+		http.Error(w, "Invalid token", http.StatusUnauthorized)
+		return
+	}
+
+	ls.usage.Lock()
+	defer ls.usage.Unlock()
+
+	id := req.FormValue("id")
+	_, exists := ls.services[id]
+	if !exists {
+		http.Error(w, "Service does not exist", http.StatusBadRequest)
+		return
+	}
+
+	delete(ls.services, id)
+}
+
+func main() {
+	masterToken = os.Getenv("MASTER_TOKEN")
+
+	state := LiveStats{
+		services: make(map[string]*Service),
+
+		usage: sync.RWMutex{},
+	}
+
+	http.HandleFunc("GET /", state.handlerMain)
+	http.HandleFunc("POST /service", state.handlerNewService)
+	http.HandleFunc("POST /service/status", state.handlerUpdateStatus)
+	http.HandleFunc("DELETE /service", state.handlerDeleteService)
+	http.ListenAndServe(":38083", nil)
+}


### PR DESCRIPTION
An HTTP updates endpoint, written in Golang, should run on any potato. This is written as a testimonial to how terribly unfit Cloud is for inherently tiny use cases like these.

I coded the entire thing in around 2 hours, with breaks in the middle. Note however I have written a Golang HTTP server before, so that made things a lot faster. But even discounting that, I reckon this, _at most_, would have taken 4 hours, thanks to the fast iteration time and having access to an interactive debugger.

The server, unoptimized, with a single service takes 8MB, and each additional takes a struct of 2 strings and 1 timestamp. The server starts within half a second (eyeball measurement). Each request on average 10ms on localhost, which is a bit less than an order of magnitude less than a warmed up AWS Lambda.

This comparsion isn't very meaningful, since this Golang server and the Lambda are doing quite different things—the latter has to do a complex networked database query on every request. The said database engine is designed to be horizontally scaled. _However_, at this scale, they both achieve the same thing, and this Golang version is both orders of magnitude faster and simpler.